### PR TITLE
doing some conf initialization earlier to avoid KeyError 

### DIFF
--- a/plaid2qfx.py
+++ b/plaid2qfx.py
@@ -256,6 +256,11 @@ def link_account():
       public_token=public_token
     )
     response = client.item_public_token_exchange(request)
+
+    # Store all of this in our config file
+    conf.add_section(link_name)
+    conf[link_name]['access_token'] = response['access_token']
+    conf[link_name]['item_id'] = response['item_id'] 
     
     # Gather some account info
     (accounts, ins_id) = get_accounts(link_name, True)
@@ -279,10 +284,6 @@ def link_account():
     bid = input("BID: ")
 
         
-    # Store all of this in our config file
-    conf.add_section(link_name)
-    conf[link_name]['access_token'] = response['access_token']
-    conf[link_name]['item_id'] = response['item_id'] 
     conf[link_name]['ins_id'] = ins_id
     conf[link_name]['routing_number'] = rn
     conf[link_name]['bid'] = bid


### PR DESCRIPTION
doing some conf initialization earlier to avoid KeyError due to uninitialized conf.

This is to fix issue number 5 : https://github.com/philliphall/plaid2qfx/issues/5

This may not be the best way or even a good way to fix this problem but the changes involved are minimal and easy to review so it can be a "bandaid" for now.