### PR TITLE
Negating balance amount reported for credit card.

### DIFF
--- a/plaid2qfx.py
+++ b/plaid2qfx.py
@@ -442,8 +442,13 @@ def process_transactions(link_name, accounts, added, modified, removed):
                                     accttype=accttype)
         
         # Add some details
-        ledgerbal = LEDGERBAL(balamt=Decimal(str(account['balances']['current'])), 
-                             dtasof=dtasof)
+
+        #plaid reports a positive balance for a credit card with a negative balance so negate it.
+        balamt=Decimal(str(account['balances']['current']))
+        if accttype == "CREDITCARD":
+            balamt = -balamt
+        ledgerbal = LEDGERBAL(balamt=balamt, dtasof=dtasof)
+
         if account['balances']['available']:
             availbal = AVAILBAL(balamt=Decimal(str(account['balances']['available'])),
                                 dtasof=dtasof)


### PR DESCRIPTION
This is because plaid reports a positive balance amount when the credit card has debt. 
This (1) seems wrong.
and  (2) is inconsistent with the way a qfx file for a credit card downloaded from a website works. 
and  (3) is not what quicken expects - resulting in a online balance that can't be reconciled to. 
Negating the value fixes all these problems.